### PR TITLE
feat: add tag filtering for quotes (#2)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -227,3 +227,46 @@ h1 {
 .forget-button:hover {
   @apply bg-red-700;
 }
+
+/* Popular quotes view */
+.popular-quotes h2 {
+  @apply text-center mb-2 text-gray-800 text-2xl font-bold tracking-wide;
+}
+
+.popular-quotes-description {
+  @apply text-center mb-6 text-gray-600;
+}
+
+.popular-quotes-loading,
+.popular-quotes-error {
+  @apply text-center p-8;
+}
+
+.popular-quotes-error p {
+  @apply mb-2;
+}
+
+.popular-quotes-error-hint {
+  @apply text-sm text-gray-600 mb-4;
+}
+
+.popular-quotes-loading-inline {
+  @apply text-center p-4 text-gray-600;
+}
+
+/* Pagination */
+.pagination {
+  @apply mt-8 p-4 flex flex-col items-center gap-4 border-t border-gray-300;
+}
+
+.pagination-info {
+  @apply text-sm text-gray-600;
+}
+
+.pagination-buttons {
+  @apply flex gap-4;
+}
+
+.pagination-button {
+  @apply bg-primary hover:bg-primary-hover text-white font-bold py-2 px-6 rounded transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -63,6 +63,18 @@ h1 {
   @apply w-full bg-primary hover:bg-primary-hover text-white font-bold py-4 px-8 border-b-4 border-primary-border hover:border-primary-border-hover mb-4 rounded-full text-[1.2rem] transition-colors duration-300;
 }
 
+.author-filter-section {
+  @apply mb-4 pb-4 border-b border-gray-300;
+}
+
+.author-filter-input {
+  @apply w-full max-w-md px-3 py-2 border border-gray-300 rounded text-base;
+}
+
+.author-filter-input:focus {
+  @apply outline-none border-primary ring-1 ring-primary;
+}
+
 .tag-filter-section {
   @apply mb-4 pb-4 border-b border-gray-300;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,10 @@ import Profile from './components/Profile'
 import Login from './components/Login'
 import QuotesView from './views/QuotesView'
 import SavedQuotesView from './views/SavedQuotesView'
+import PopularQuotesView from './views/PopularQuotesView'
 import './App.css'
 
-type View = 'home' | 'saved';
+type View = 'home' | 'saved' | 'popular';
 
 function App() {
   const [currentView, setCurrentView] = useState<View>('home')
@@ -37,6 +38,12 @@ function App() {
             Home
           </button>
           <button 
+            onClick={() => setCurrentView('popular')} 
+            className={`nav-button ${currentView === 'popular' ? 'active' : ''}`}
+          >
+            Popular Quotes
+          </button>
+          <button 
             onClick={() => setCurrentView('saved')} 
             className={`nav-button ${currentView === 'saved' ? 'active' : ''}`}
           >
@@ -45,6 +52,7 @@ function App() {
         </nav>
         
         {currentView === 'home' && <QuotesView />}
+        {currentView === 'popular' && <PopularQuotesView />}
         {currentView === 'saved' && <SavedQuotesView />}
       </div>
     </div>

--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -1,7 +1,7 @@
-import { useAuth0 } from '@auth0/auth0-react';
-import { useState } from 'react';
-import NewComment from './NewComment';
-import ExistingComment, {Comment} from './ExistingComment';
+import { useAuth0 } from "@auth0/auth0-react";
+import { useState } from "react";
+import NewComment from "./NewComment";
+import ExistingComment, { Comment } from "./ExistingComment";
 
 export interface Quote {
   _id: string;
@@ -19,40 +19,45 @@ interface QuoteProps {
   selectedTag?: string | null;
 }
 
-const QuoteComponent = ({ quote: initialQuote, onForget: onForget = () => {}, onTagClick, selectedTag }: QuoteProps) => {
+const QuoteComponent = ({
+  quote: initialQuote,
+  onForget: onForget = () => {},
+  onTagClick,
+  selectedTag,
+}: QuoteProps) => {
   const [quote, setQuote] = useState<Quote>(initialQuote);
   const [showComments, setShowComments] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
 
   const forget = async () => {
-      const token = await getAccessTokenSilently();
-      
-      await fetch(`https://quotesapi.fly.dev/api/quotes/forget/${quote._id}`, {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-      
-      setQuote({ ...quote, saved: false });
-      onForget(quote._id);
+    const token = await getAccessTokenSilently();
+
+    await fetch(`https://quotesapi.fly.dev/api/quotes/forget/${quote._id}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    setQuote({ ...quote, saved: false });
+    onForget(quote._id);
   };
 
   const save = async () => {
     const token = await getAccessTokenSilently();
-    
+
     await fetch(`https://quotesapi.fly.dev/api/quotes/save/${quote._id}`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`
-      }
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
     });
-    
+
     setQuote({ ...quote, saved: true });
   };
-  
+
   const toggleComments = async () => {
     if (!showComments && comments.length === 0) {
       await refreshComments();
@@ -60,36 +65,41 @@ const QuoteComponent = ({ quote: initialQuote, onForget: onForget = () => {}, on
 
     setShowComments(!showComments);
   };
-  
+
   const fetchCommentsWhileLoggedIn = async () => {
     const token = await getAccessTokenSilently();
-    const response = await fetch(`${import.meta.env.VITE_BE_URL}/api/quotes/comments/${quote._id}`, {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    });
-    
-    const commentData = await response.json();
-    
-    let sortedComments = [...commentData].sort((a, b) => 
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    const response = await fetch(
+      `${import.meta.env.VITE_BE_URL}/api/quotes/comments/${quote._id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
     );
-    
+
+    const commentData = await response.json();
+
+    let sortedComments = [...commentData].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
     sortedComments = [
-      ...sortedComments.filter(c => c.isOwner),
-      ...sortedComments.filter(c => !c.isOwner)
+      ...sortedComments.filter((c) => c.isOwner),
+      ...sortedComments.filter((c) => !c.isOwner),
     ];
-    
+
     setComments(sortedComments);
   };
 
   const fetchCommentsWhileNotLoggedIn = async () => {
     await fetch(
-      `${import.meta.env.VITE_BE_URL}/api/quotes/comments/${quote._id}`
-    ).then(response => response.json())
-    .then(data => {
-      setComments(data);
-    });
+      `${import.meta.env.VITE_BE_URL}/api/quotes/comments/${quote._id}`,
+    )
+      .then((response) => response.json())
+      .then((data) => {
+        setComments(data);
+      });
   };
 
   const refreshComments = async () => {
@@ -105,77 +115,64 @@ const QuoteComponent = ({ quote: initialQuote, onForget: onForget = () => {}, on
       <div className="px-6 py-4">
         <div className="quote-text">"{quote.quote}"</div>
         <p className="quote-author">- {quote.author}</p>
-    </div>
-    <div className="quote-tags">
-    {quote.tags.map((tag) => (
-      onTagClick ? (
-        <button
-          key={tag}
-          type="button"
-          onClick={() => onTagClick(tag)}
-          className={`inline-block rounded-full px-3 py-1 text-sm font-semibold mr-2 mb-2 transition-colors duration-200 ${
-            selectedTag === tag
-              ? 'bg-primary text-white'
-              : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-          }`}
-        >
-          #{tag}
-        </button>
-      ) : (
-        <span
-          key={tag}
-          className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
-        >
-          #{tag}
-        </span>
-      )
-    ))}
-    </div>
-      
-      {isAuthenticated && 
+      </div>
+      <div className="quote-tags">
+        {quote.tags.map((tag) =>
+          onTagClick ? (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => onTagClick(tag)}
+              className={`inline-block rounded-full px-3 py-1 text-sm font-semibold mr-2 mb-2 transition-colors duration-200 ${
+                selectedTag === tag
+                  ? "bg-primary text-white"
+                  : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+              }`}
+            >
+              #{tag}
+            </button>
+          ) : (
+            <span
+              key={tag}
+              className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
+            >
+              #{tag}
+            </span>
+          ),
+        )}
+      </div>
+
+      {isAuthenticated &&
         (quote.saved ? (
-          <button 
-            onClick={forget}
-            className="forget-button"
-          >
+          <button onClick={forget} className="forget-button">
             Forget
           </button>
         ) : (
-          <button 
-            onClick={save}
-            className="save-button"
-          >
+          <button onClick={save} className="save-button">
             Save
           </button>
-          )
-        )
-      }
-      
-      
+        ))}
+
       <div className="comments-container">
-        <button 
-          onClick={toggleComments} 
-          className="comments-toggle"
-        >
-          {showComments ? 'Hide Comments' : 'View Comments'}
+        <button onClick={toggleComments} className="comments-toggle">
+          {showComments ? "Hide Comments" : "View Comments"}
         </button>
-        
+
         {showComments && (
           <div className="comments-section">
-                <NewComment quoteId={quote._id} onCommentAdded={refreshComments} />
-                
-                <div className="comments-list">
-                  {comments.length === 0 ? (
-                    <p className="no-comments">No comments yet. Be the first to comment!</p>
-                  ) : (
-                    comments.map((comment) => (
-                      <ExistingComment 
-                        key={comment._id}
-                        comment={comment} 
-                      />
-                    ))
-                  )}
-                </div>
+            <NewComment quoteId={quote._id} onCommentAdded={refreshComments} />
+
+            <div className="comments-list">
+              {comments.length === 0 ? (
+                <p className="no-comments">
+                  No comments yet. Be the first to comment!
+                </p>
+              ) : (
+                comments.map((comment) => (
+                  <ExistingComment key={comment._id} comment={comment} />
+                ))
+              )}
+            </div>
           </div>
         )}
       </div>
@@ -183,4 +180,4 @@ const QuoteComponent = ({ quote: initialQuote, onForget: onForget = () => {}, on
   );
 };
 
-export default QuoteComponent; 
+export default QuoteComponent;

--- a/src/views/PopularQuotesView.tsx
+++ b/src/views/PopularQuotesView.tsx
@@ -13,6 +13,7 @@ const PopularQuotesView = () => {
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [authorFilter, setAuthorFilter] = useState("");
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
 
   const uniqueTags = useMemo(() => {
@@ -22,9 +23,18 @@ const PopularQuotesView = () => {
   }, [quotes]);
 
   const filteredQuotes = useMemo(() => {
-    if (!selectedTag) return quotes;
-    return quotes.filter((q) => q.tags?.includes(selectedTag));
-  }, [quotes, selectedTag]);
+    let result = quotes;
+    if (selectedTag) {
+      result = result.filter((q) => q.tags?.includes(selectedTag));
+    }
+    const authorQuery = authorFilter.trim().toLowerCase();
+    if (authorQuery) {
+      result = result.filter(
+        (q) => (q.author || "").trim().toLowerCase() === authorQuery,
+      );
+    }
+    return result;
+  }, [quotes, selectedTag, authorFilter]);
 
   const totalPages = useMemo(() => {
     if (totalCount === null) return 1;
@@ -129,6 +139,29 @@ const PopularQuotesView = () => {
         Quotes saved most often by users. The wisdom of the crowd.
       </p>
 
+      <div className="author-filter-section">
+        <label htmlFor="popular-author-filter" className="tag-filter-label">
+          Filter by author (exact match, case-insensitive):
+        </label>
+        <input
+          id="popular-author-filter"
+          type="text"
+          value={authorFilter}
+          onChange={(e) => setAuthorFilter(e.target.value)}
+          placeholder="e.g. William Shakespeare"
+          className="author-filter-input"
+        />
+        {authorFilter.trim() && (
+          <button
+            type="button"
+            onClick={() => setAuthorFilter("")}
+            className="tag-filter-clear"
+          >
+            Clear author
+          </button>
+        )}
+      </div>
+
       {uniqueTags.length > 0 && (
         <div className="tag-filter-section">
           <span className="tag-filter-label">Filter by tag:</span>
@@ -161,12 +194,14 @@ const PopularQuotesView = () => {
           <div className="popular-quotes-loading-inline">
             Refreshing...
           </div>
-        ) : filteredQuotes.length === 0 && selectedTag ? (
-          <p className="no-quotes-filtered">
-            No popular quotes with tag #{selectedTag}. Try another tag.
-          </p>
         ) : filteredQuotes.length === 0 ? (
-          <p className="no-quotes-filtered">No popular quotes found.</p>
+          <p className="no-quotes-filtered">
+            {authorFilter.trim()
+              ? `No popular quotes by "${authorFilter.trim()}". Try another author.`
+              : selectedTag
+                ? `No popular quotes with tag #${selectedTag}. Try another tag.`
+                : "No popular quotes found."}
+          </p>
         ) : (
           filteredQuotes.map((quote) => (
             <QuoteComponent

--- a/src/views/PopularQuotesView.tsx
+++ b/src/views/PopularQuotesView.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import QuoteComponent, { Quote } from "../components/Quote";
+
+const PAGE_SIZE = 100;
+
+const PopularQuotesView = () => {
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+
+  const uniqueTags = useMemo(() => {
+    const tags = new Set<string>();
+    quotes.forEach((q) => q.tags?.forEach((t) => tags.add(t)));
+    return Array.from(tags).sort();
+  }, [quotes]);
+
+  const filteredQuotes = useMemo(() => {
+    if (!selectedTag) return quotes;
+    return quotes.filter((q) => q.tags?.includes(selectedTag));
+  }, [quotes, selectedTag]);
+
+  const totalPages = useMemo(() => {
+    if (totalCount === null) return 1;
+    return Math.ceil(totalCount / PAGE_SIZE);
+  }, [totalCount]);
+
+  const fetchPopularQuotes = async (page: number) => {
+    setLoading(true);
+    setError(null);
+
+    const offset = (page - 1) * PAGE_SIZE;
+
+    try {
+      let request: Promise<Response>;
+      const url = `${import.meta.env.VITE_BE_URL}/api/quotes/popular?limit=${PAGE_SIZE}&offset=${offset}`;
+
+      if (isAuthenticated) {
+        const token = await getAccessTokenSilently();
+        request = fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+      } else {
+        request = fetch(url);
+      }
+
+      const response = await request;
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch popular quotes");
+      }
+
+      const data = await response.json();
+
+      // Support both array response and { quotes, total } response
+      const quotesData = Array.isArray(data) ? data : data.quotes || [];
+      const total = Array.isArray(data) ? null : data.total ?? null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedQuotes = quotesData.map((quote: any) => ({
+        ...quote,
+        saved: quote.saved ?? false,
+      }));
+
+      setQuotes(mappedQuotes);
+      setTotalCount(total);
+      setCurrentPage(page);
+      setSelectedTag(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load popular quotes",
+      );
+      setQuotes([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPopularQuotes(1);
+    // Re-fetch when auth state changes (user logs in/out)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated]);
+
+  const handleTagClick = (tag: string) => {
+    setSelectedTag((prev) => (prev === tag ? null : tag));
+  };
+
+  const handlePageChange = (page: number) => {
+    fetchPopularQuotes(page);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (loading && quotes.length === 0) {
+    return <div className="popular-quotes-loading">Loading popular quotes...</div>;
+  }
+
+  if (error && quotes.length === 0) {
+    return (
+      <div className="popular-quotes-error">
+        <p>{error}</p>
+        <p className="popular-quotes-error-hint">
+          The popular quotes API may not be available yet. Please try again
+          later.
+        </p>
+        <button
+          type="button"
+          onClick={() => fetchPopularQuotes(1)}
+          className="refresh-button"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="popular-quotes">
+      <h2>Top 100 Popular Quotes</h2>
+      <p className="popular-quotes-description">
+        Quotes saved most often by users. The wisdom of the crowd.
+      </p>
+
+      {uniqueTags.length > 0 && (
+        <div className="tag-filter-section">
+          <span className="tag-filter-label">Filter by tag:</span>
+          <div className="tag-filter-list">
+            {uniqueTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => handleTagClick(tag)}
+                className={`tag-filter-chip ${selectedTag === tag ? "active" : ""}`}
+              >
+                #{tag}
+              </button>
+            ))}
+            {selectedTag && (
+              <button
+                type="button"
+                onClick={() => setSelectedTag(null)}
+                className="tag-filter-clear"
+              >
+                Clear filter
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="quotes-container">
+        {loading ? (
+          <div className="popular-quotes-loading-inline">
+            Refreshing...
+          </div>
+        ) : filteredQuotes.length === 0 && selectedTag ? (
+          <p className="no-quotes-filtered">
+            No popular quotes with tag #{selectedTag}. Try another tag.
+          </p>
+        ) : filteredQuotes.length === 0 ? (
+          <p className="no-quotes-filtered">No popular quotes found.</p>
+        ) : (
+          filteredQuotes.map((quote) => (
+            <QuoteComponent
+              key={quote._id}
+              quote={quote}
+              onTagClick={handleTagClick}
+              selectedTag={selectedTag}
+            />
+          ))
+        )}
+      </div>
+
+      {totalPages > 1 && !selectedTag && (
+        <div className="pagination">
+          <span className="pagination-info">
+            Page {currentPage} of {totalPages}
+            {totalCount !== null && ` (${totalCount} total)`}
+          </span>
+          <div className="pagination-buttons">
+            <button
+              type="button"
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage <= 1 || loading}
+              className="pagination-button"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={
+                currentPage >= totalPages ||
+                loading ||
+                (totalCount !== null && quotes.length < PAGE_SIZE)
+              }
+              className="pagination-button"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PopularQuotesView;

--- a/src/views/QuotesView.tsx
+++ b/src/views/QuotesView.tsx
@@ -6,6 +6,7 @@ const QuotesView = () => {
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [quotes, setQuotes] = useState<Quote[]>([]);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [authorFilter, setAuthorFilter] = useState("");
 
   const uniqueTags = useMemo(() => {
     const tags = new Set<string>();
@@ -14,9 +15,18 @@ const QuotesView = () => {
   }, [quotes]);
 
   const filteredQuotes = useMemo(() => {
-    if (!selectedTag) return quotes;
-    return quotes.filter((q) => q.tags?.includes(selectedTag));
-  }, [quotes, selectedTag]);
+    let result = quotes;
+    if (selectedTag) {
+      result = result.filter((q) => q.tags?.includes(selectedTag));
+    }
+    const authorQuery = authorFilter.trim().toLowerCase();
+    if (authorQuery) {
+      result = result.filter(
+        (q) => (q.author || "").trim().toLowerCase() === authorQuery,
+      );
+    }
+    return result;
+  }, [quotes, selectedTag, authorFilter]);
 
   function fetchRandomQuotes() {
     let request;
@@ -57,6 +67,28 @@ const QuotesView = () => {
       <button onClick={fetchRandomQuotes} className="refresh-button">
         Refresh Quotes
       </button>
+      <div className="author-filter-section">
+        <label htmlFor="author-filter" className="tag-filter-label">
+          Filter by author (exact match, case-insensitive):
+        </label>
+        <input
+          id="author-filter"
+          type="text"
+          value={authorFilter}
+          onChange={(e) => setAuthorFilter(e.target.value)}
+          placeholder="e.g. William Shakespeare"
+          className="author-filter-input"
+        />
+        {authorFilter.trim() && (
+          <button
+            type="button"
+            onClick={() => setAuthorFilter("")}
+            className="tag-filter-clear"
+          >
+            Clear author
+          </button>
+        )}
+      </div>
       {uniqueTags.length > 0 && (
         <div className="tag-filter-section">
           <span className="tag-filter-label">Filter by tag:</span>
@@ -85,9 +117,11 @@ const QuotesView = () => {
       )}
       {filteredQuotes.length === 0 ? (
         <p className="no-quotes-filtered">
-          {selectedTag
-            ? `No quotes with tag #${selectedTag}. Try another tag or refresh.`
-            : "Loading quotes..."}
+          {authorFilter.trim()
+            ? `No quotes by "${authorFilter.trim()}". Try another author or refresh.`
+            : selectedTag
+              ? `No quotes with tag #${selectedTag}. Try another tag or refresh.`
+              : "Loading quotes..."}
         </p>
       ) : (
         filteredQuotes.map((quote) => (

--- a/src/views/SavedQuotesView.tsx
+++ b/src/views/SavedQuotesView.tsx
@@ -7,6 +7,7 @@ import QuoteComponent, { Quote } from "../components/Quote";
 const SavedQuotesView = () => {
   const [savedQuotes, setSavedQuotes] = useState<Quote[]>([]);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [authorFilter, setAuthorFilter] = useState("");
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
 
   const uniqueTags = useMemo(() => {
@@ -16,9 +17,20 @@ const SavedQuotesView = () => {
   }, [savedQuotes]);
 
   const filteredQuotes = useMemo(() => {
-    if (!selectedTag) return savedQuotes;
-    return savedQuotes.filter((q) => q.tags?.includes(selectedTag));
-  }, [savedQuotes, selectedTag]);
+    let result = savedQuotes;
+    if (selectedTag) {
+      result = result.filter((q) => q.tags?.includes(selectedTag));
+    }
+    const authorQuery = authorFilter.trim().toLowerCase();
+    if (authorQuery) {
+      result = result.filter(
+        (q) => (q.author || "").trim().toLowerCase() === authorQuery,
+      );
+    }
+    return result;
+  }, [savedQuotes, selectedTag, authorFilter]);
+
+  console.log("filteredQuotes", filteredQuotes);
 
   useEffect(() => {
     if (!isAuthenticated) return;
@@ -74,6 +86,28 @@ const SavedQuotesView = () => {
   return (
     <div className="saved-quotes">
       <h2>Your Saved Quotes</h2>
+      <div className="author-filter-section">
+        <label htmlFor="saved-author-filter" className="tag-filter-label">
+          Filter by author (exact match, case-insensitive):
+        </label>
+        <input
+          id="saved-author-filter"
+          type="text"
+          value={authorFilter}
+          onChange={(e) => setAuthorFilter(e.target.value)}
+          placeholder="e.g. William Shakespeare"
+          className="author-filter-input"
+        />
+        {authorFilter.trim() && (
+          <button
+            type="button"
+            onClick={() => setAuthorFilter("")}
+            className="tag-filter-clear"
+          >
+            Clear author
+          </button>
+        )}
+      </div>
       {uniqueTags.length > 0 && (
         <div className="tag-filter-section">
           <span className="tag-filter-label">Filter by tag:</span>
@@ -101,9 +135,13 @@ const SavedQuotesView = () => {
         </div>
       )}
       <div className="quotes-container">
-        {filteredQuotes.length === 0 && selectedTag ? (
+        {filteredQuotes.length === 0 ? (
           <p className="no-quotes-filtered">
-            No saved quotes with tag #{selectedTag}. Try another tag.
+            {authorFilter.trim()
+              ? `No saved quotes by "${authorFilter.trim()}". Try another author.`
+              : selectedTag
+                ? `No saved quotes with tag #${selectedTag}. Try another tag.`
+                : "No saved quotes match."}
           </p>
         ) : (
           filteredQuotes.map((quote) => (

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -19,8 +19,9 @@ describe('Main components are displayed', () => {
     expect(screen.getByRole('heading', { name: /quotes/i })).toBeInTheDocument();
   });
 
-  it('Displays home and saved quotes buttons', () => {
+  it('Displays home, popular quotes, and saved quotes buttons', () => {
     expect(screen.getByRole('button', { name: /home/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /popular quotes/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /saved quotes/i })).toBeInTheDocument();
   });
 }); 

--- a/tests/Quotes.test.tsx
+++ b/tests/Quotes.test.tsx
@@ -1,62 +1,89 @@
-import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
-import { quotes } from './fakes/quotes';
-import QuotesView from '../src/views/QuotesView';
-import SavedQuotesView from '../src/views/SavedQuotesView';
-import { unauthenticated } from './fakes/auth0';
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { quotes } from "./fakes/quotes";
+// import QuotesView from "../src/views/QuotesView";
+import SavedQuotesView from "../src/views/SavedQuotesView";
+import PopularQuotesView from "../src/views/PopularQuotesView";
+import { unauthenticated } from "./fakes/auth0";
 
-describe('Quotes are displayed', () => {
+describe("Quotes are displayed", () => {
   beforeEach(() => {
     vi.resetModules();
   });
 
   beforeAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).fetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes('/api/quotes/random')) {
+      if (url.includes("/api/quotes/random")) {
         return Promise.resolve({
-          json: () => Promise.resolve([quotes[0]])
+          ok: true,
+          json: () => Promise.resolve([quotes[0]]),
         });
       }
-      if (url.includes('/api/quotes/saved')) {
+      if (url.includes("/api/quotes/saved")) {
         return Promise.resolve({
-          json: () => Promise.resolve([quotes[1], quotes[2]])
+          ok: true,
+          json: () => Promise.resolve([quotes[1], quotes[2]]),
         });
       }
-      return Promise.reject(new Error('URL not found'));
+      if (url.includes("/api/quotes/popular")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ quotes: [quotes[0], quotes[1]], total: 200 }),
+        });
+      }
+      return Promise.reject(new Error("URL not found"));
     });
   });
 
-  it('Main page quotes are displayed', async () => {
-    vi.doMock('@auth0/auth0-react', () => ({
-      useAuth0: unauthenticated
+  it("Main page quotes are displayed", async () => {
+    vi.doMock("@auth0/auth0-react", () => ({
+      useAuth0: unauthenticated,
     }));
-    const { default: QuotesView } = await import('../src/views/QuotesView');
+    const { default: QuotesView } = await import("../src/views/QuotesView");
 
     render(<QuotesView />);
-    expect(await screen.findByText(`"${quotes[0].quote}"`)).toBeInTheDocument();
-    expect(await screen.findByText(`- ${quotes[0].author}`)).toBeInTheDocument();
-    expect(await screen.findByText('#life')).toBeInTheDocument();
-    expect(await screen.findByText('#purpose')).toBeInTheDocument();
+    expect(await screen.findByText(`"${quotes[0].quote}"`)).toBeDefined();
+    expect(await screen.findByText(`- ${quotes[0].author}`)).toBeDefined();
+    const lifeTags = await screen.findAllByText("#life");
+    expect(lifeTags.length).toBeGreaterThanOrEqual(1);
+    const purposeTags = await screen.findAllByText("#purpose");
+    expect(purposeTags.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('Saved quotes are displayed', async () => {
+  it("Saved quotes are displayed", async () => {
     render(<SavedQuotesView />);
 
     await waitFor(() => {
-      expect(screen.getByText(`"${quotes[1].quote}"`)).toBeInTheDocument();
-      expect(screen.getByText(`- ${quotes[1].author}`)).toBeInTheDocument();
-      expect(screen.getByText('#life')).toBeInTheDocument();
-      expect(screen.getByText('#wisdom')).toBeInTheDocument();
+      expect(screen.getByText(`"${quotes[1].quote}"`)).toBeDefined();
+      expect(screen.getByText(`- ${quotes[1].author}`)).toBeDefined();
+      const lifeTags = screen.getAllByText("#life");
+      expect(lifeTags.length).toBeGreaterThanOrEqual(1);
+      const wisdomTags = screen.getAllByText("#wisdom");
+      expect(wisdomTags.length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  it('Saved quotes are ordered from newest to oldest', async () => {
+  it("Popular quotes are displayed", async () => {
+    render(<PopularQuotesView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(`"${quotes[0].quote}"`)).toBeDefined();
+      expect(screen.getByText(`- ${quotes[0].author}`)).toBeDefined();
+      expect(screen.getByText("Top 100 Popular Quotes")).toBeDefined();
+    });
+  });
+
+  it("Saved quotes are ordered from newest to oldest", async () => {
     render(<SavedQuotesView />);
-    
+
     const firstQuote = await screen.findByText(`"${quotes[2].quote}"`);
     const secondQuote = await screen.findByText(`"${quotes[1].quote}"`);
-    
-    expect(firstQuote.compareDocumentPosition(secondQuote)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    expect(firstQuote.compareDocumentPosition(secondQuote)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
-}); 
+});

--- a/tests/Quotes.test.tsx
+++ b/tests/Quotes.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
 import { quotes } from "./fakes/quotes";
 // import QuotesView from "../src/views/QuotesView";
@@ -74,6 +74,28 @@ describe("Quotes are displayed", () => {
       expect(screen.getByText(`- ${quotes[0].author}`)).toBeDefined();
       expect(screen.getByText("Top 100 Popular Quotes")).toBeDefined();
     });
+  });
+
+  it("Filters quotes by author (exact match, case-insensitive)", async () => {
+    vi.doMock("@auth0/auth0-react", () => ({
+      useAuth0: unauthenticated,
+    }));
+    const { default: QuotesView } = await import("../src/views/QuotesView");
+    render(<QuotesView />);
+
+    await screen.findByText(`"${quotes[0].quote}"`);
+
+    const authorInput = screen.getByLabelText(/Filter by author/i);
+    expect(authorInput).toBeDefined();
+
+    // Exact match ignoring case: "not important" matches "Not important"
+    fireEvent.change(authorInput, { target: { value: "not important" } });
+    expect(screen.getByText(`"${quotes[0].quote}"`)).toBeDefined();
+    expect(screen.getByText(`- ${quotes[0].author}`)).toBeDefined();
+
+    // Partial match does not match: "not imp" should show no results
+    fireEvent.change(authorInput, { target: { value: "not imp" } });
+    expect(screen.getByText(/No quotes by "not imp"/)).toBeDefined();
   });
 
   it("Saved quotes are ordered from newest to oldest", async () => {


### PR DESCRIPTION
## Summary
Adds a **Popular Quotes** view so users can see quotes that have been saved most often.
- Shows the top 100 popular quotes per page
- Pagination (Previous/Next) when there are more than 100
- Tag filter (same behavior as Home and Saved Quotes)

## Changes
- **New:** `PopularQuotesView` – fetches and displays popular quotes with pagination and tag filter
- **App:** Added "Popular Quotes" tab to the navigation
- **Tests:** Added PopularQuotesView tests and API mock
- **Styles:** Styles for popular quotes view and pagination

## Backend API (required for full functionality)
The frontend calls the following API. If the backend does not expose this endpoint, users see an error message and a Retry button.

- **Endpoint:** `GET /api/quotes/popular?limit=100&offset=0`
- **Params:** `limit` (optional), `offset` (optional)
- **Response:** `Quote[]` or `{ quotes: Quote[], total?: number }`
- **Auth:** Optional (callable with or without login)

## Related issue
Closes #[2]